### PR TITLE
Fix missing escaping of newlines and tabs in message

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,19 @@
 var xmlEscape = require('xml-escape')
 
 /**
+ * Escapes an XML attribute value.
+ *
+ * @param {string} value Attribute value to escape
+ * @return {string}
+ */
+function xmlEscapeAttr (value) {
+  return xmlEscape(value)
+    .replace(/\n/g, '&#xA;')
+    .replace(/\r/g, '&#xD;')
+    .replace(/\t/g, '&#x9;')
+}
+
+/**
  * Extract property and return as an XML attribute.
  *
  * Example:
@@ -13,7 +26,7 @@ var xmlEscape = require('xml-escape')
  * @return {string}
  */
 function attr (message, prop) {
-  return ' ' + prop + '="' + xmlEscape('' + message[prop]) + '"'
+  return ' ' + prop + '="' + xmlEscapeAttr('' + message[prop]) + '"'
 }
 
 /**

--- a/test/fixtures/01.js
+++ b/test/fixtures/01.js
@@ -44,6 +44,12 @@ module.exports = {
           message: '& " \' < >',
           source: 'eslint.indent',
           unexpectedKey: 'should not appear in output'
+        },
+        {
+          line: 11,
+          column: 12,
+          severity: 'error',
+          message: 'message\nwith\r\nnewlines and\ttabs'
         }
       ]
     }

--- a/test/fixtures/01.xml
+++ b/test/fixtures/01.xml
@@ -8,5 +8,6 @@
 <error line="5" column="6" severity="warning" message="jumped over" />
 <error line="7" column="8" severity="error" message="the lazy dog" />
 <error line="9" column="10" severity="error" message="&amp; &quot; &apos; &lt; &gt;" source="eslint.indent" />
+<error line="11" column="12" severity="error" message="message&#xA;with&#xD;&#xA;newlines and&#x9;tabs" />
 </file>
 </checkstyle>


### PR DESCRIPTION
According to the XML spec, when using these in attribute values they should be escaped to be preserved; otherwise they will be interpreted as an ordinary space. The xmlEscape function only performs the necessary escaping for text node contents, so we add a wrapper around it to escape for attribute values.